### PR TITLE
Pouvoir créer une activité même dans une année déjà passée

### DIFF
--- a/templates/activite/actions.html.twig
+++ b/templates/activite/actions.html.twig
@@ -27,11 +27,11 @@
             </li>
         </ul>
     </nav>
-    {% if courante %}
+    {#% if courante %#}
         <div class="d-flex flex-row justify-content-center mb-3">
             <a href="#" data-ajax="{{ path('nouvelle_autre_activite') }}" class="btn btn-primary ajax-reload" data-toggle="tooltip" title="Nouvelle action"><i class="fas fa-plus"></i> Nouvelle action</a>
         </div>
-    {% endif %}
+    {# % endif %#}
     <div class="row">
         {% if activites is empty %}
         <div class="col-sm-6 col-md-4 col-lg-3">


### PR DESCRIPTION
Si l’année scolaire est passée, l’assemblée générale, elle, se produit l’année d’après.
S’il y a eu des oublis pour préparer l’AG, il faut pouvoir ajouter des activités sur les année passées