### PR TITLE
84 precisions activites

### DIFF
--- a/migrations/Version20230603135033.php
+++ b/migrations/Version20230603135033.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20230603135033 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE activite ADD description LONGTEXT DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE activite DROP description');
+    }
+}

--- a/migrations/Version20230603150817.php
+++ b/migrations/Version20230603150817.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20230603150817 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE activite ADD ordre INT NOT NULL DEFAULT 0');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE activite DROP ordre');
+    }
+}

--- a/migrations/Version20230603223039.php
+++ b/migrations/Version20230603223039.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20230603223039 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('DROP TABLE migration_versions');
+        $this->addSql('ALTER TABLE activite ADD only_for_planning TINYINT(1) NOT NULL DEFAULT 0, CHANGE ordre ordre INT NOT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE migration_versions (version VARCHAR(14) CHARACTER SET utf8mb3 NOT NULL COLLATE `utf8mb3_unicode_ci`, executed_at DATETIME DEFAULT NULL COMMENT \'(DC2Type:datetime_immutable)\', PRIMARY KEY(version)) DEFAULT CHARACTER SET utf8mb3 COLLATE `utf8mb3_unicode_ci` ENGINE = InnoDB COMMENT = \'\' ');
+        $this->addSql('ALTER TABLE activite DROP only_for_planning, CHANGE ordre ordre INT DEFAULT 0 NOT NULL');
+    }
+}

--- a/migrations/Version20230605211209.php
+++ b/migrations/Version20230605211209.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20230605211209 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('CREATE TABLE type_activite (id INT AUTO_INCREMENT NOT NULL, etablissement_id INT DEFAULT NULL, nom VARCHAR(255) NOT NULL, INDEX IDX_758A72E9FF631228 (etablissement_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE `utf8mb4_unicode_ci` ENGINE = InnoDB');
+        $this->addSql('ALTER TABLE type_activite ADD CONSTRAINT FK_758A72E9FF631228 FOREIGN KEY (etablissement_id) REFERENCES etablissement (id)');
+        $this->addSql('ALTER TABLE activite ADD type_id INT DEFAULT NULL, CHANGE only_for_planning only_for_planning TINYINT(1) NOT NULL');
+        $this->addSql('ALTER TABLE activite ADD CONSTRAINT FK_B8755515C54C8C93 FOREIGN KEY (type_id) REFERENCES type_activite (id)');
+        $this->addSql('CREATE INDEX IDX_B8755515C54C8C93 ON activite (type_id)');
+        $this->addSql("INSERT INTO type_activite(id, nom) VALUES (-1, 'Autre (précisez)') ");
+        $this->addSql("INSERT INTO type_activite(nom) VALUES 
+                              ('Jeu à lot immédiat'),
+                              ('Jeu à meilleur score'),
+                              ('Tirage au sort'),
+                              ('Vente directe'),
+                              ('Animation'),
+                              ('Surveillance')");
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE activite DROP FOREIGN KEY FK_B8755515C54C8C93');
+        $this->addSql('ALTER TABLE type_activite DROP FOREIGN KEY FK_758A72E9FF631228');
+        $this->addSql('DROP TABLE type_activite');
+        $this->addSql('DROP INDEX IDX_B8755515C54C8C93 ON activite');
+        $this->addSql('ALTER TABLE activite DROP type_id, CHANGE only_for_planning only_for_planning TINYINT(1) DEFAULT 0 NOT NULL');
+    }
+}

--- a/migrations/Version20230605232318.php
+++ b/migrations/Version20230605232318.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20230605232318 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE activite ADD regle LONGTEXT DEFAULT NULL');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->addSql('ALTER TABLE activite DROP regle');
+    }
+}

--- a/public/css/kermesse_index.css
+++ b/public/css/kermesse_index.css
@@ -1,0 +1,9 @@
+.loader {
+    height: 310px;
+}
+.activity-card-handle {
+    position: absolute;
+    left: 5px;
+    top: 5px;
+    cursor: grab;
+}

--- a/public/js/activite_form.js
+++ b/public/js/activite_form.js
@@ -7,10 +7,18 @@ $(function() {
     form.on('collection-widget-added', changeVisibilityBlocs)
     form.on('collection-widget-removed', affichageAucunCreneau)
     form.on('change', '#activite_onlyForPlanning', changeVisibilityNbBenevoles)
+    form.on("change", "#activite_type", affichageNewType)
 
     function changeVisibilityBlocs() {
         affichageAucunCreneau()
         changeVisibilityNbBenevoles()
+        affichageNewType()
+    }
+
+    function affichageNewType() {
+        const selectedType = parseInt($("#activite_type").val())
+        console.log(selectedType)
+        $("#activite_new_type_activite").closest(".form-group").toggle(selectedType === -1)
     }
 
     function affichageAucunCreneau() {

--- a/public/js/activite_form.js
+++ b/public/js/activite_form.js
@@ -1,21 +1,34 @@
 $(function() {
+    const form = $('form')
     $('#activite_creneaux fieldset').each(function (){
-        addRemoveLinkCollectionWidget($(this));
-    });
-    var affichageAucunCreneau = function () {
-        var nbFieldest = $('#activite_creneaux fieldset').length;
-        var noCreneau = $('#no_creneau');
+        addRemoveLinkCollectionWidget($(this))
+    })
+    changeVisibilityBlocs()
+    form.on('collection-widget-added', changeVisibilityBlocs)
+    form.on('collection-widget-removed', affichageAucunCreneau)
+    form.on('change', '#activite_onlyForPlanning', changeVisibilityNbBenevoles)
+
+    function changeVisibilityBlocs() {
+        affichageAucunCreneau()
+        changeVisibilityNbBenevoles()
+    }
+
+    function affichageAucunCreneau() {
+        const nbFieldest = $('#activite_creneaux fieldset').length
+        const noCreneau = $('#no_creneau')
         if (nbFieldest === 0) {
-            $('#activite_creneaux').append('<fieldset class="form-group" id="no_creneau">Aucun créneau horaire</fieldset>');
+            $('#activite_creneaux').append('<fieldset class="form-group" id="no_creneau">Aucun créneau horaire</fieldset>')
         } else if (noCreneau.length > 0) {
-            noCreneau.remove();
+            noCreneau.remove()
         }
-    };
-    affichageAucunCreneau();
-    $('form').on('collection-widget-added', function (event) {
-        affichageAucunCreneau();
-    });
-    $('form').on('collection-widget-removed', function () {
-        affichageAucunCreneau();
-    });
+    }
+
+    function changeVisibilityNbBenevoles() {
+        const onlyForPlanning = $("#activite_onlyForPlanning").is(':checked')
+        if (onlyForPlanning) {
+            form.find('.creneau-nb-benevoles-requis input').val('0')
+        }
+        form.find('.creneau-nb-benevoles-requis').toggle(!onlyForPlanning)
+        form.find('#activite_accepteTickets').closest('.form-group').toggle(!onlyForPlanning)
+    }
 });

--- a/public/js/kermesse_index.js
+++ b/public/js/kermesse_index.js
@@ -1,0 +1,32 @@
+$( function() {
+    const activitiesBloc = $("#activity-list")
+    activitiesBloc.sortable({
+        cursor: "grabbing",
+        handle: ".activity-card-handle",
+        tolerance: "pointer",
+        stop: updatePosition
+    })
+    activitiesBloc.disableSelection()
+
+    /**
+     * Update the position of the moved activity
+     * @param _
+     * @param ui
+     */
+    function updatePosition(_,ui) {
+        const activity = ui.item
+        const moveUrl = activity.data('move-url').replace('__position__', getPositionInList(activity))
+        $.ajax({url: moveUrl}).done(function(result) {
+            console.log({moveUrl, result})
+        })
+    }
+
+    /**
+     * Getting the position of the activity (in the activities bloc)
+     * @param activity
+     * @returns {number}
+     */
+    function getPositionInList(activity) {
+        return activitiesBloc.children().index(activity) + 1
+    }
+} )

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -158,7 +158,8 @@ $(function() {
         });
     });
     body.on('click', '.modal .dismiss', function () {
-        $(this).closest('.modal').modal('hide');
+        const modal = $(this).closest('.modal')
+        modal.modal('hide')
     });
     body.on('click', '[data-ajax]', function () {
         $('head .ajax-stylesheet').remove();

--- a/public/js/planning.js
+++ b/public/js/planning.js
@@ -82,4 +82,14 @@ $(function() {
             modale.modal('show');
         });
     } );
+
+    const modalActivity = $('#activite-desc-modal');
+    const modalActivityTitle = modalActivity.find('#activite-desc-modal-title');
+    const modalActivityBody = modalActivity.find('.modal-body');
+
+    $('.activite-desc-listener').on('click', '.activite-desc-btn', function() {
+        const button = $(this);
+        modalActivityTitle.text(button.data('activite'));
+        modalActivityBody.html(button.data('description'));
+    });
 });

--- a/src/Controller/ActiviteController.php
+++ b/src/Controller/ActiviteController.php
@@ -16,10 +16,10 @@ use App\Repository\ActiviteRepository;
 use App\Repository\DepenseRepository;
 use App\Repository\RecetteRepository;
 use App\Service\ActiviteCardGenerator;
+use App\Service\ActiviteMover;
 use App\Service\DepenseRowGenerator;
 use App\Service\RecetteRowGenerator;
 use DateTimeImmutable;
-use Doctrine\DBAL\DBALException;
 use Doctrine\ORM\NonUniqueResultException;
 use Doctrine\ORM\NoResultException;
 use Exception;
@@ -141,7 +141,6 @@ class ActiviteController extends MyController
      * @param DepenseRowGenerator $dRowGenerator
      * @param Request $request
      * @return Response
-     * @throws DBALException
      * @throws NoResultException
      * @throws NonUniqueResultException
      */
@@ -211,6 +210,20 @@ class ActiviteController extends MyController
             'activite' => ActivitePlanning::createFromEntity($activite),
             'menu' => $this->getMenu($activite->getKermesse(), static::MENU_ACTIVITES)
         ]);
+    }
+
+    /**
+     * Move an activity and return all moved ones (in json format)
+     * @Route("/activites/{id<\d+>}/moveTo/{position}", name="move_activity")
+     * @Security("activite.isProprietaire(user)")
+     * @param Activite $activite
+     * @param int $position
+     * @param ActiviteMover $mover
+     * @return Response
+     */
+    public function move(Activite $activite, int $position, ActiviteMover $mover): Response
+    {
+        return $this->json(['moved' => $mover->moveActivityTo($activite, $position)]);
     }
 
     /**

--- a/src/Controller/BenevoleController.php
+++ b/src/Controller/BenevoleController.php
@@ -14,6 +14,7 @@ use App\Entity\Creneau;
 use App\Entity\Etablissement;
 use App\Form\InscriptionType;
 use App\Form\MigrationType;
+use App\Repository\ActiviteRepository;
 use App\Repository\BenevoleRepository;
 use App\Repository\InscriptionBenevoleRepository;
 use App\Repository\KermesseRepository;
@@ -200,11 +201,11 @@ class BenevoleController extends MyController
      * @return Response
      * @throws NonUniqueResultException
      */
-    public function showPlanning(string $code, KermesseRepository $rKermesse): Response
+    public function showPlanning(string $code, KermesseRepository $rKermesse, ActiviteRepository $rActivite): Response
     {
         $etablissement = $this->getEtablissementByCode($code);
         $kermesse = $rKermesse->findCouranteByEtablissement($etablissement);
-        $planning = Planning::createFromKermesse($kermesse);
+        $planning = Planning::createFromKermesse($kermesse->getId(), $rActivite->findByKermesseId($kermesse->getId()));
         return $this->render('kermesse/planning.html.twig', [
             'planning' => $planning,
             'codeEtablissement' => $code,

--- a/src/Controller/KermesseController.php
+++ b/src/Controller/KermesseController.php
@@ -346,15 +346,19 @@ class KermesseController extends MyController
      * @Security("kermesse.isProprietaire(user)")
      * @param Kermesse $kermesse
      * @param KermesseCardGenerator $cardGenerator
+     * @param ActiviteRepository $rActivite
      * @return Response
      * @throws NoResultException
      * @throws NonUniqueResultException
      */
-    public function gererBenevoles(Kermesse $kermesse, KermesseCardGenerator $cardGenerator): Response {
+    public function gererBenevoles(Kermesse $kermesse, KermesseCardGenerator $cardGenerator, ActiviteRepository $rActivite): Response {
         return $this->render('kermesse/benevoles.html.twig', [
             'kermesse' => $cardGenerator->generate($kermesse),
-            'activites' => $kermesse->getActivites()->map(function (Activite $activite) {
-                return ActivitePlanning::createFromEntity($activite);
+            'activites' => array_filter(array_map(
+                [ActivitePlanning::class, 'createFromEntity'],
+                $rActivite->findByKermesseId($kermesse->getId())
+            ), function (ActivitePlanning $activitePlanning) {
+                return !$activitePlanning->isOnlyForPlanning();
             }),
             'menu' => $this->getMenu($kermesse, static::MENU_ACTIVITES)
         ]);

--- a/src/DataTransfer/ActiviteCard.php
+++ b/src/DataTransfer/ActiviteCard.php
@@ -215,10 +215,10 @@ class ActiviteCard
     }
 
     /**
-     * Le descriptif de l'activité
-     * @return string|null
+     * Le descriptif de l'activité (avec son type)
+     * @return ActiviteDescriptionModal
      */
-    public function getDescription(): ?string {
-        return $this->activite->getDescription();
+    public function getDescription(): ActiviteDescriptionModal {
+        return new ActiviteDescriptionModal($this->activite);
     }
 }

--- a/src/DataTransfer/ActiviteCard.php
+++ b/src/DataTransfer/ActiviteCard.php
@@ -213,4 +213,12 @@ class ActiviteCard
     {
         return $this->activite;
     }
+
+    /**
+     * Le descriptif de l'activité
+     * @return string|null
+     */
+    public function getDescription(): ?string {
+        return $this->activite->getDescription();
+    }
 }

--- a/src/DataTransfer/ActiviteDescriptionModal.php
+++ b/src/DataTransfer/ActiviteDescriptionModal.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\DataTransfer;
+
+use App\Entity\Activite;
+
+class ActiviteDescriptionModal
+{
+    /**
+     * @var string|null
+     */
+    private $type;
+    /**
+     * @var string|null
+     */
+    private $description;
+
+    /**
+     * @param Activite $activite
+     */
+    public function __construct(Activite $activite)
+    {
+        $type = $activite->getType();
+        $this->type = $type ? $type->getNom() : null;
+        $this->description = $activite->getDescription();
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getType(): ?string
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEmpty(): bool {
+        return !$this->description && !$this->type;
+    }
+}

--- a/src/DataTransfer/ActiviteDescriptionModal.php
+++ b/src/DataTransfer/ActiviteDescriptionModal.php
@@ -14,6 +14,10 @@ class ActiviteDescriptionModal
      * @var string|null
      */
     private $description;
+    /**
+     * @var string|null
+     */
+    private $regle;
 
     /**
      * @param Activite $activite
@@ -23,6 +27,7 @@ class ActiviteDescriptionModal
         $type = $activite->getType();
         $this->type = $type ? $type->getNom() : null;
         $this->description = $activite->getDescription();
+        $this->regle = $activite->getRegle();
     }
 
     /**
@@ -42,9 +47,17 @@ class ActiviteDescriptionModal
     }
 
     /**
+     * @return string|null
+     */
+    public function getRegle(): ?string
+    {
+        return $this->regle;
+    }
+
+    /**
      * @return bool
      */
     public function isEmpty(): bool {
-        return !$this->description && !$this->type;
+        return !$this->description && !$this->type && !$this->regle;
     }
 }

--- a/src/DataTransfer/ActivitePlanning.php
+++ b/src/DataTransfer/ActivitePlanning.php
@@ -30,6 +30,11 @@ class ActivitePlanning extends PlageHoraire
     private $description;
 
     /**
+     * @var bool|null
+     */
+    private $onlyForPlanning;
+
+    /**
      * @param Activite $entity
      * @return static
      */
@@ -38,7 +43,8 @@ class ActivitePlanning extends PlageHoraire
         $activite = (new self())
             ->setNom($entity->getNom())
             ->setId($entity->getId())
-            ->setDescription($entity->getDescription());
+            ->setDescription($entity->getDescription())
+            ->setOnlyForPlanning($entity->isOnlyForPlanning());
         foreach ($entity->getCreneaux() as $creneau) {
             $creneauPlanning = CreneauPlanning::createFromEntity($creneau);
             $activite->addCreneau($creneauPlanning);
@@ -132,6 +138,24 @@ class ActivitePlanning extends PlageHoraire
     public function setDescription(?string $description): ActivitePlanning
     {
         $this->description = $description;
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isOnlyForPlanning(): bool
+    {
+        return $this->onlyForPlanning;
+    }
+
+    /**
+     * @param bool $onlyForPlanning
+     * @return ActivitePlanning
+     */
+    public function setOnlyForPlanning(bool $onlyForPlanning): ActivitePlanning
+    {
+        $this->onlyForPlanning = $onlyForPlanning;
         return $this;
     }
 

--- a/src/DataTransfer/ActivitePlanning.php
+++ b/src/DataTransfer/ActivitePlanning.php
@@ -25,7 +25,7 @@ class ActivitePlanning extends PlageHoraire
     private $lignesCreneaux = [];
 
     /**
-     * @var string|null
+     * @var ActiviteDescriptionModal
      */
     private $description;
 
@@ -43,7 +43,7 @@ class ActivitePlanning extends PlageHoraire
         $activite = (new self())
             ->setNom($entity->getNom())
             ->setId($entity->getId())
-            ->setDescription($entity->getDescription())
+            ->setDescription(new ActiviteDescriptionModal($entity))
             ->setOnlyForPlanning($entity->isOnlyForPlanning());
         foreach ($entity->getCreneaux() as $creneau) {
             $creneauPlanning = CreneauPlanning::createFromEntity($creneau);
@@ -124,20 +124,20 @@ class ActivitePlanning extends PlageHoraire
     }
 
     /**
-     * @return string|null
+     * @return ActiviteDescriptionModal|null
      */
-    public function getDescription(): ?string
+    public function getDescription(): ?ActiviteDescriptionModal
     {
         return $this->description;
     }
 
     /**
-     * @param string|null $description
+     * @param ActiviteDescriptionModal|null $descriptionModale
      * @return ActivitePlanning
      */
-    public function setDescription(?string $description): ActivitePlanning
+    public function setDescription(?ActiviteDescriptionModal $descriptionModale): ActivitePlanning
     {
-        $this->description = $description;
+        $this->description = $descriptionModale;
         return $this;
     }
 

--- a/src/DataTransfer/ActivitePlanning.php
+++ b/src/DataTransfer/ActivitePlanning.php
@@ -25,12 +25,20 @@ class ActivitePlanning extends PlageHoraire
     private $lignesCreneaux = [];
 
     /**
+     * @var string|null
+     */
+    private $description;
+
+    /**
      * @param Activite $entity
      * @return static
      */
     public static function createFromEntity(Activite $entity): self
     {
-        $activite = (new self())->setNom($entity->getNom())->setId($entity->getId());
+        $activite = (new self())
+            ->setNom($entity->getNom())
+            ->setId($entity->getId())
+            ->setDescription($entity->getDescription());
         foreach ($entity->getCreneaux() as $creneau) {
             $creneauPlanning = CreneauPlanning::createFromEntity($creneau);
             $activite->addCreneau($creneauPlanning);
@@ -106,6 +114,24 @@ class ActivitePlanning extends PlageHoraire
     public function setId(int $id): self
     {
         $this->id = $id;
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    /**
+     * @param string|null $description
+     * @return ActivitePlanning
+     */
+    public function setDescription(?string $description): ActivitePlanning
+    {
+        $this->description = $description;
         return $this;
     }
 

--- a/src/DataTransfer/MovedActivityDto.php
+++ b/src/DataTransfer/MovedActivityDto.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\DataTransfer;
+
+class MovedActivityDto implements \JsonSerializable
+{
+    /**
+     * @var int
+     */
+    private $id;
+    /**
+     * @var int
+     */
+    private $oldPosition;
+    /**
+     * @var int
+     */
+    private $newPosition;
+
+    /**
+     * @param int $id
+     * @param int $oldPosition
+     * @param int $newPosition
+     */
+    public function __construct(int $id, int $oldPosition, int $newPosition)
+    {
+        $this->id= $id;
+        $this->oldPosition= $oldPosition;
+        $this->newPosition= $newPosition;
+    }
+
+    /**
+     * For json serialization
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return [
+            'id' => $this->id,
+            'oldPosition' => $this->oldPosition,
+            'newPosition' => $this->newPosition,
+        ];
+    }
+}

--- a/src/DataTransfer/Planning.php
+++ b/src/DataTransfer/Planning.php
@@ -2,7 +2,7 @@
 
 namespace App\DataTransfer;
 
-use App\Entity\Kermesse;
+use App\Entity\Activite;
 
 /**
  * Class Planning
@@ -25,7 +25,7 @@ class Planning extends PlageHoraire
 
     /**
      * @param int $idKermesse
-     * @param array $activites
+     * @param Activite[] $activites
      * @return static
      */
     public static function createFromKermesse(int $idKermesse, array $activites): self
@@ -33,7 +33,8 @@ class Planning extends PlageHoraire
         $planning = new self();
         $planning->idKermesse = $idKermesse;
         foreach ($activites as $activite) {
-            if ($activite->getDate() === null) {
+            // If no planning for this activity, next
+            if ($activite->getDate() === null || $activite->getCreneaux()->isEmpty()) {
                 continue;
             }
             $dateStr = $activite->getDate()->format('Ymd');

--- a/src/DataTransfer/Planning.php
+++ b/src/DataTransfer/Planning.php
@@ -24,14 +24,15 @@ class Planning extends PlageHoraire
     private $idKermesse;
 
     /**
-     * @param Kermesse $kermesse
+     * @param int $idKermesse
+     * @param array $activites
      * @return static
      */
-    public static function createFromKermesse(Kermesse $kermesse): self
+    public static function createFromKermesse(int $idKermesse, array $activites): self
     {
         $planning = new self();
-        $planning->idKermesse = $kermesse->getId();
-        foreach ($kermesse->getActivites() as $activite) {
+        $planning->idKermesse = $idKermesse;
+        foreach ($activites as $activite) {
             if ($activite->getDate() === null) {
                 continue;
             }

--- a/src/Entity/Activite.php
+++ b/src/Entity/Activite.php
@@ -95,6 +95,11 @@ class Activite extends MyEntity
      */
     private $type;
 
+    /**
+     * @ORM\Column(type="text", nullable=true)
+     */
+    private $regle;
+
     public function __construct()
     {
         $this->depenses = new ArrayCollection();
@@ -347,6 +352,18 @@ class Activite extends MyEntity
     public function setType(?TypeActivite $type): self
     {
         $this->type = $type;
+
+        return $this;
+    }
+
+    public function getRegle(): ?string
+    {
+        return $this->regle;
+    }
+
+    public function setRegle(?string $regle): self
+    {
+        $this->regle = $regle;
 
         return $this;
     }

--- a/src/Entity/Activite.php
+++ b/src/Entity/Activite.php
@@ -80,6 +80,11 @@ class Activite extends MyEntity
      */
     private $description;
 
+    /**
+     * @ORM\Column(type="integer")
+     */
+    private $ordre = 0;
+
     public function __construct()
     {
         $this->depenses = new ArrayCollection();
@@ -296,6 +301,18 @@ class Activite extends MyEntity
     public function setDescription(?string $description): self
     {
         $this->description = $description;
+
+        return $this;
+    }
+
+    public function getOrdre(): ?int
+    {
+        return $this->ordre;
+    }
+
+    public function setOrdre(int $ordre): self
+    {
+        $this->ordre = $ordre;
 
         return $this;
     }

--- a/src/Entity/Activite.php
+++ b/src/Entity/Activite.php
@@ -75,6 +75,11 @@ class Activite extends MyEntity
      */
     private $date;
 
+    /**
+     * @ORM\Column(type="text", nullable=true)
+     */
+    private $description;
+
     public function __construct()
     {
         $this->depenses = new ArrayCollection();
@@ -279,6 +284,18 @@ class Activite extends MyEntity
     public function setDate(?\DateTimeInterface $date): self
     {
         $this->date = $date;
+
+        return $this;
+    }
+
+    public function getDescription(): ?string
+    {
+        return $this->description;
+    }
+
+    public function setDescription(?string $description): self
+    {
+        $this->description = $description;
 
         return $this;
     }

--- a/src/Entity/Activite.php
+++ b/src/Entity/Activite.php
@@ -85,6 +85,11 @@ class Activite extends MyEntity
      */
     private $ordre = 0;
 
+    /**
+     * @ORM\Column(type="boolean")
+     */
+    private $onlyForPlanning = false;
+
     public function __construct()
     {
         $this->depenses = new ArrayCollection();
@@ -313,6 +318,18 @@ class Activite extends MyEntity
     public function setOrdre(int $ordre): self
     {
         $this->ordre = $ordre;
+
+        return $this;
+    }
+
+    public function isOnlyForPlanning(): ?bool
+    {
+        return $this->onlyForPlanning;
+    }
+
+    public function setOnlyForPlanning(bool $onlyForPlanning): self
+    {
+        $this->onlyForPlanning = $onlyForPlanning;
 
         return $this;
     }

--- a/src/Entity/Activite.php
+++ b/src/Entity/Activite.php
@@ -90,6 +90,11 @@ class Activite extends MyEntity
      */
     private $onlyForPlanning = false;
 
+    /**
+     * @ORM\ManyToOne(targetEntity=TypeActivite::class)
+     */
+    private $type;
+
     public function __construct()
     {
         $this->depenses = new ArrayCollection();
@@ -330,6 +335,18 @@ class Activite extends MyEntity
     public function setOnlyForPlanning(bool $onlyForPlanning): self
     {
         $this->onlyForPlanning = $onlyForPlanning;
+
+        return $this;
+    }
+
+    public function getType(): ?TypeActivite
+    {
+        return $this->type;
+    }
+
+    public function setType(?TypeActivite $type): self
+    {
+        $this->type = $type;
 
         return $this;
     }

--- a/src/Entity/Etablissement.php
+++ b/src/Entity/Etablissement.php
@@ -73,11 +73,17 @@ class Etablissement implements UserInterface
      */
     private $resetPwdKey;
 
+    /**
+     * @ORM\OneToMany(targetEntity=TypeActivite::class, mappedBy="etablissement")
+     */
+    private $typeActivites;
+
     public function __construct()
     {
         $this->kermesses = new ArrayCollection();
         $this->membres = new ArrayCollection();
         $this->admin = false;
+        $this->typeActivites = new ArrayCollection();
     }
 
     public function getId()
@@ -291,6 +297,36 @@ class Etablissement implements UserInterface
     public function setResetPwdKey(?string $resetPwdKey): self
     {
         $this->resetPwdKey = $resetPwdKey;
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, TypeActivite>
+     */
+    public function getTypeActivites(): Collection
+    {
+        return $this->typeActivites;
+    }
+
+    public function addTypeActivite(TypeActivite $typeActivite): self
+    {
+        if (!$this->typeActivites->contains($typeActivite)) {
+            $this->typeActivites[] = $typeActivite;
+            $typeActivite->setEtablissement($this);
+        }
+
+        return $this;
+    }
+
+    public function removeTypeActivite(TypeActivite $typeActivite): self
+    {
+        if ($this->typeActivites->removeElement($typeActivite)) {
+            // set the owning side to null (unless already changed)
+            if ($typeActivite->getEtablissement() === $this) {
+                $typeActivite->setEtablissement(null);
+            }
+        }
 
         return $this;
     }

--- a/src/Entity/TypeActivite.php
+++ b/src/Entity/TypeActivite.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace App\Entity;
+
+use App\Repository\TypeActiviteRepository;
+use Doctrine\ORM\Mapping as ORM;
+
+/**
+ * @ORM\Entity(repositoryClass=TypeActiviteRepository::class)
+ */
+class TypeActivite
+{
+    /**
+     * @ORM\Id
+     * @ORM\GeneratedValue
+     * @ORM\Column(type="integer")
+     */
+    private $id;
+
+    /**
+     * @ORM\Column(type="string", length=255)
+     */
+    private $nom;
+
+    /**
+     * @ORM\ManyToOne(targetEntity=Etablissement::class, inversedBy="typeActivites")
+     */
+    private $etablissement;
+
+    public function getId(): ?int
+    {
+        return $this->id;
+    }
+
+    public function getNom(): ?string
+    {
+        return $this->nom;
+    }
+
+    public function setNom(string $nom): self
+    {
+        $this->nom = $nom;
+
+        return $this;
+    }
+
+    public function getEtablissement(): ?Etablissement
+    {
+        return $this->etablissement;
+    }
+
+    public function setEtablissement(?Etablissement $etablissement): self
+    {
+        $this->etablissement = $etablissement;
+
+        return $this;
+    }
+}

--- a/src/Form/ActiviteType.php
+++ b/src/Form/ActiviteType.php
@@ -19,8 +19,7 @@ class ActiviteType extends AbstractType
         $disabledIfCaisseCentrale = ['disabled' => $data instanceof Activite ? $data->isCaisseCentrale() : false];
         $builder->add('nom', null, $disabledIfCaisseCentrale)
             ->add('date', DatePickerType::class, $disabledIfCaisseCentrale)
-            ->add('description', TextareaType::class, $disabledIfCaisseCentrale)
-            ->add('ordre', NumberType::class, ['disabled' => true]);
+            ->add('description', TextareaType::class, array_merge(['required' => false], $disabledIfCaisseCentrale));
         if ($options['withKermesse']) {
             $builder->add('creneaux', CollectionType::class, [
                     'label' => 'Créneaux horaire',

--- a/src/Form/ActiviteType.php
+++ b/src/Form/ActiviteType.php
@@ -3,10 +3,13 @@
 namespace App\Form;
 
 use App\Entity\Activite;
+use App\Entity\TypeActivite;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -15,30 +18,46 @@ class ActiviteType extends AbstractType
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $data = $builder->getData();
-        $disabledIfCaisseCentrale = ['disabled' => $data instanceof Activite ? $data->isCaisseCentrale() : false];
+        $disabledIfCaisseCentrale = [
+            'disabled' => $data instanceof Activite
+                ? $data->isCaisseCentrale()
+                : false,
+        ];
         $builder->add('nom', null, $disabledIfCaisseCentrale)
             ->add('date', DatePickerType::class, $disabledIfCaisseCentrale)
-            ->add('description', TextareaType::class, array_merge(['required' => false], $disabledIfCaisseCentrale))
+            ->add('type', EntityType::class, array_merge([
+                'required'      => false,
+                'class'         => TypeActivite::class,
+                'choice_label'  => 'nom',
+                'choices'       => $options['availableTypes'],
+            ], $disabledIfCaisseCentrale))
+            ->add("new_type_activite", TextType::class, array_merge([
+                'required'      => false,
+                "mapped"        => false,
+                'label'         => 'Nouveau type',
+            ], $disabledIfCaisseCentrale))
+            ->add('description', TextareaType::class, array_merge([
+                'required'      => false,
+            ], $disabledIfCaisseCentrale))
             ->add('onlyForPlanning', CheckboxType::class, array_merge([
-                'required' => false,
-                'label' => 'Uniquement pour le planning'
+                'required'      => false,
+                'label'         => 'Uniquement pour le planning',
             ], $disabledIfCaisseCentrale));
         if ($options['withKermesse']) {
             $builder->add('creneaux', CollectionType::class, [
-                    'label' => 'Créneaux horaire',
-                    'by_reference' => false,
-                    'entry_type' => CreneauType::class,
-                    'allow_add' => true,
-                    'allow_delete' => true,
-                    'prototype' => true,
-                ]);
+                'label'         => 'Créneaux horaire',
+                'by_reference'  => false,
+                'entry_type'    => CreneauType::class,
+                'allow_add'     => true,
+                'allow_delete'  => true,
+                'prototype'     => true,
+            ]);
         }
         if ($options['tickets'] && $options['withKermesse']) {
-            $builder
-                ->add('accepteTickets', CheckboxType::class, [
-                    'label'    => 'Accepte les tickets ?',
-                    'required' => false
-                ]);
+            $builder->add('accepteTickets', CheckboxType::class, [
+                'label'         => 'Accepte les tickets ?',
+                'required'      => false,
+            ]);
         }
     }
 
@@ -47,7 +66,8 @@ class ActiviteType extends AbstractType
         $resolver->setDefaults([
             'data_class' => Activite::class,
             'tickets' => true,
-            'withKermesse' => true
+            'withKermesse' => true,
+            'availableTypes' => true,
         ]);
     }
 }

--- a/src/Form/ActiviteType.php
+++ b/src/Form/ActiviteType.php
@@ -39,6 +39,10 @@ class ActiviteType extends AbstractType
             ->add('description', TextareaType::class, array_merge([
                 'required'      => false,
             ], $disabledIfCaisseCentrale))
+            ->add('regle', TextareaType::class, array_merge([
+                'required'      => false,
+                'label'         => 'Règle du jeu',
+            ], $disabledIfCaisseCentrale))
             ->add('onlyForPlanning', CheckboxType::class, array_merge([
                 'required'      => false,
                 'label'         => 'Uniquement pour le planning',

--- a/src/Form/ActiviteType.php
+++ b/src/Form/ActiviteType.php
@@ -6,6 +6,7 @@ use App\Entity\Activite;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -18,7 +19,8 @@ class ActiviteType extends AbstractType
         $disabledIfCaisseCentrale = ['disabled' => $data instanceof Activite ? $data->isCaisseCentrale() : false];
         $builder->add('nom', null, $disabledIfCaisseCentrale)
             ->add('date', DatePickerType::class, $disabledIfCaisseCentrale)
-            ->add('description', TextareaType::class, $disabledIfCaisseCentrale);
+            ->add('description', TextareaType::class, $disabledIfCaisseCentrale)
+            ->add('ordre', NumberType::class, ['disabled' => true]);
         if ($options['withKermesse']) {
             $builder->add('creneaux', CollectionType::class, [
                     'label' => 'Créneaux horaire',

--- a/src/Form/ActiviteType.php
+++ b/src/Form/ActiviteType.php
@@ -6,7 +6,6 @@ use App\Entity\Activite;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
-use Symfony\Component\Form\Extension\Core\Type\NumberType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -19,7 +18,11 @@ class ActiviteType extends AbstractType
         $disabledIfCaisseCentrale = ['disabled' => $data instanceof Activite ? $data->isCaisseCentrale() : false];
         $builder->add('nom', null, $disabledIfCaisseCentrale)
             ->add('date', DatePickerType::class, $disabledIfCaisseCentrale)
-            ->add('description', TextareaType::class, array_merge(['required' => false], $disabledIfCaisseCentrale));
+            ->add('description', TextareaType::class, array_merge(['required' => false], $disabledIfCaisseCentrale))
+            ->add('onlyForPlanning', CheckboxType::class, array_merge([
+                'required' => false,
+                'label' => 'Uniquement pour le planning'
+            ], $disabledIfCaisseCentrale));
         if ($options['withKermesse']) {
             $builder->add('creneaux', CollectionType::class, [
                     'label' => 'Créneaux horaire',

--- a/src/Form/ActiviteType.php
+++ b/src/Form/ActiviteType.php
@@ -6,6 +6,7 @@ use App\Entity\Activite;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 use Symfony\Component\Form\Extension\Core\Type\CollectionType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 
@@ -16,7 +17,8 @@ class ActiviteType extends AbstractType
         $data = $builder->getData();
         $disabledIfCaisseCentrale = ['disabled' => $data instanceof Activite ? $data->isCaisseCentrale() : false];
         $builder->add('nom', null, $disabledIfCaisseCentrale)
-            ->add('date', DatePickerType::class, $disabledIfCaisseCentrale);
+            ->add('date', DatePickerType::class, $disabledIfCaisseCentrale)
+            ->add('description', TextareaType::class, $disabledIfCaisseCentrale);
         if ($options['withKermesse']) {
             $builder->add('creneaux', CollectionType::class, [
                     'label' => 'Créneaux horaire',

--- a/src/Form/CreneauType.php
+++ b/src/Form/CreneauType.php
@@ -15,7 +15,8 @@ class CreneauType extends AbstractType
     {
         $builder
             ->add('nbBenevolesRecquis', IntegerType::class, [
-                'label' => 'Nombre de bénévoles requis'
+                'label' => 'Nombre de bénévoles requis',
+                'row_attr' => ['class' => 'creneau-nb-benevoles-requis'],
             ])
             ->add('debut', TimeType::class, [
                 'label' => 'De',
@@ -35,7 +36,8 @@ class CreneauType extends AbstractType
     public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults([
-            'data_class' => Creneau::class
+            'data_class' => Creneau::class,
+            'attr' => ['class' => 'activite-creneau']
         ]);
     }
 }

--- a/src/Repository/ActiviteRepository.php
+++ b/src/Repository/ActiviteRepository.php
@@ -244,22 +244,25 @@ class ActiviteRepository extends ServiceEntityRepository
      * Get all the activities which will move
      * @param int $kermesseId
      * @param int $from
-     * @param int $to
+     * @param int|null $to
      * @return Activite[] All the activities which will move
      */
-    public function findWillMove(int $kermesseId, int $from, int $to): array
+    public function findWillMove(int $kermesseId, int $from, ?int $to = null): array
     {
-        return $this->createQueryBuilder('a')
+        $min = $to === null ? $from : min($from, $to);
+        $max = $to === null? null : max($from, $to);
+        $qb = $this->createQueryBuilder('a')
             ->innerJoin('a.kermesse', 'k')
             ->addSelect('k')
             ->andWhere('k.id = :kermesseId')
             ->andWhere('a.ordre >= :min')
-            ->andWhere('a.ordre <= :max')
             ->setParameter('kermesseId', $kermesseId)
-            ->setParameter('min', min($from, $to))
-            ->setParameter('max', max($from, $to))
-            ->getQuery()
-            ->getResult()
-            ;
+            ->setParameter('min', $min);
+
+        if ($max !== null) {
+            $qb->andWhere('a.ordre <= :max')->setParameter('max', $max);
+        }
+
+        return $qb->getQuery()->getResult();
     }
 }

--- a/src/Repository/ActiviteRepository.php
+++ b/src/Repository/ActiviteRepository.php
@@ -10,6 +10,7 @@ use DateTimeInterface;
 use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\ORM\NonUniqueResultException;
+use Doctrine\ORM\NoResultException;
 use Doctrine\ORM\QueryBuilder;
 use Doctrine\Persistence\ManagerRegistry;
 use Exception;
@@ -264,5 +265,24 @@ class ActiviteRepository extends ServiceEntityRepository
         }
 
         return $qb->getQuery()->getResult();
+    }
+
+    /**
+     * Getting the next available position
+     * @param Kermesse $kermesse
+     * @return int
+     */
+    public function getNextPosition(Kermesse $kermesse): int {
+        try {
+            $result = $this->createQueryBuilder('a')
+                ->andWhere('a.kermesse = :kermesse')
+                ->setParameter('kermesse', $kermesse)
+                ->select('COALESCE(MAX(a.ordre),0) as ordre')
+                ->getQuery()
+                ->getSingleScalarResult();
+        } catch (Exception $exc) {
+            return 0;
+        }
+        return ($result ?? 0) + 1;
     }
 }

--- a/src/Repository/ActiviteRepository.php
+++ b/src/Repository/ActiviteRepository.php
@@ -40,7 +40,8 @@ class ActiviteRepository extends ServiceEntityRepository
             ->addSelect('k')
             ->andWhere('k.id = :kermesseId')
             ->setParameter('kermesseId', $kermesseId)
-            ->orderBy('a.nom', 'ASC')
+            ->orderBy('a.ordre', 'ASC')
+            ->addOrderBy('a.nom', 'ASC')
             ->getQuery()
             ->getResult()
         ;
@@ -218,5 +219,47 @@ class ActiviteRepository extends ServiceEntityRepository
             ->getArrayResult();
         // Regroupement
         return $this->regrouperDepensesRecettes($recettes, $depenses);
+    }
+
+    /**
+     * Les activités d'une kermesse qui n'ont pas d'ordre
+     * @param int $kermesseId
+     * @return Activite[] Returns an array of Activite objects
+     */
+    public function findUnorderedByKermesseId(int $kermesseId):array
+    {
+        return $this->createQueryBuilder('a')
+            ->innerJoin('a.kermesse', 'k')
+            ->addSelect('k')
+            ->andWhere('k.id = :kermesseId')
+            ->andWhere('a.ordre = :ordre')
+            ->setParameter('kermesseId', $kermesseId)
+            ->setParameter('ordre', 0)
+            ->getQuery()
+            ->getResult()
+            ;
+    }
+
+    /**
+     * Get all the activities which will move
+     * @param int $kermesseId
+     * @param int $from
+     * @param int $to
+     * @return Activite[] All the activities which will move
+     */
+    public function findWillMove(int $kermesseId, int $from, int $to): array
+    {
+        return $this->createQueryBuilder('a')
+            ->innerJoin('a.kermesse', 'k')
+            ->addSelect('k')
+            ->andWhere('k.id = :kermesseId')
+            ->andWhere('a.ordre >= :min')
+            ->andWhere('a.ordre <= :max')
+            ->setParameter('kermesseId', $kermesseId)
+            ->setParameter('min', min($from, $to))
+            ->setParameter('max', max($from, $to))
+            ->getQuery()
+            ->getResult()
+            ;
     }
 }

--- a/src/Repository/TypeActiviteRepository.php
+++ b/src/Repository/TypeActiviteRepository.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Repository;
+
+use App\Entity\Etablissement;
+use App\Entity\TypeActivite;
+use Doctrine\Bundle\DoctrineBundle\Repository\ServiceEntityRepository;
+use Doctrine\Persistence\ManagerRegistry;
+
+/**
+ * @extends ServiceEntityRepository<TypeActivite>
+ *
+ * @method TypeActivite|null find($id, $lockMode = null, $lockVersion = null)
+ * @method TypeActivite|null findOneBy(array $criteria, array $orderBy = null)
+ * @method TypeActivite[]    findAll()
+ * @method TypeActivite[]    findBy(array $criteria, array $orderBy = null, $limit = null, $offset = null)
+ */
+class TypeActiviteRepository extends ServiceEntityRepository
+{
+    public function __construct(ManagerRegistry $registry)
+    {
+        parent::__construct($registry, TypeActivite::class);
+    }
+
+    public function add(TypeActivite $entity, bool $flush = false): void
+    {
+        $this->getEntityManager()->persist($entity);
+
+        if ($flush) {
+            $this->getEntityManager()->flush();
+        }
+    }
+
+    public function remove(TypeActivite $entity, bool $flush = false): void
+    {
+        $this->getEntityManager()->remove($entity);
+
+        if ($flush) {
+            $this->getEntityManager()->flush();
+        }
+    }
+
+    /**
+     * Types d’activité pour un établissement (retourne aussi les types communs à tous les établissements)
+     * @param Etablissement $etablissement
+     * @return array
+     */
+    public function findByEtablissement(Etablissement $etablissement): array
+    {
+        return $this->createQueryBuilder('t')
+            ->where('t.etablissement = :etablissement')
+            ->orWhere('t.etablissement IS NULL')
+            ->setParameter('etablissement', $etablissement)
+            ->orderBy('t.id', 'DESC')
+            ->getQuery()->getResult();
+    }
+
+//    /**
+//     * @return TypeActivite[] Returns an array of TypeActivite objects
+//     */
+//    public function findByExampleField($value): array
+//    {
+//        return $this->createQueryBuilder('t')
+//            ->andWhere('t.exampleField = :val')
+//            ->setParameter('val', $value)
+//            ->orderBy('t.id', 'ASC')
+//            ->setMaxResults(10)
+//            ->getQuery()
+//            ->getResult()
+//        ;
+//    }
+
+    /**
+     * Recherche si déjà existante
+     * @param Etablissement $etablissement
+     * @param string $nom
+     * @return TypeActivite|null
+     */
+    public function findOneByNom(Etablissement $etablissement, string $nom): ?TypeActivite
+    {
+        $list = $this->createQueryBuilder('t')
+            ->where('t.nom = :nom')
+            ->andWhere("t.etablissement = :etablissement")
+            ->orWhere('t.nom = :nom')
+            ->andWhere('t.etablissement IS NULL')
+            ->setParameter('nom', $nom)
+            ->setParameter('etablissement', $etablissement)
+            ->getQuery()
+            ->getResult();
+        return array_shift($list);
+    }
+}

--- a/src/Service/ActiviteMover.php
+++ b/src/Service/ActiviteMover.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace App\Service;
+
+use App\DataTransfer\MovedActivityDto;
+use App\Entity\Activite;
+use App\Repository\ActiviteRepository;
+use Doctrine\ORM\EntityManagerInterface;
+
+/**
+ * Service to move an activity to another position
+ * It will also chane the order of some other activities
+ */
+class ActiviteMover
+{
+    /**
+     * @var ActiviteRepository
+     */
+    private $rActivite;
+
+    /**
+     * @var EntityManagerInterface
+     */
+    private $entityManager;
+
+    /**
+     * Dummy constructor
+     * @param ActiviteRepository $rActivite
+     * @param EntityManagerInterface $entityManager
+     */
+    public function __construct(ActiviteRepository $rActivite, EntityManagerInterface $entityManager)
+    {
+        $this->rActivite= $rActivite;
+        $this->entityManager = $entityManager;
+    }
+
+    /**
+     * Change the order of the activity with the new position
+     * and then change the order of the other activities (depends on the initial position and the new one)
+     * finally return all modified activities
+     * @param Activite $activite
+     * @param int $newPosition
+     * @return MovedActivityDto[]
+     */
+    public function moveActivityTo(Activite $activite, int $newPosition): array {
+        $oldPosition = $activite->getOrdre();
+        // No change at all ...
+        if ($oldPosition === $newPosition) {
+            return [];
+        }
+        // If the new position is greater than the old one, some activities will be move downward
+        // else they will be move upward
+        $increment = 1;
+        if ($oldPosition < $newPosition) {
+            $increment = -1;
+        }
+        // Getting all activities which will move
+        $toMove = $this->rActivite->findWillMove($activite->getKermesse()->getId(), $oldPosition, $newPosition);
+        $movedActivities = [];
+        foreach ($toMove as $activityToMove) {
+            $from = $activityToMove->getOrdre();
+            // If the activity to move is the initial one, is new position is $newPosition
+            // else it will be the old one plus or minus 1 (depends on the difference between the old and the new position)
+            if ($activityToMove->getId() === $activite->getId()) {
+                $to = $newPosition;
+            } else {
+                $to = $activityToMove->getOrdre() + $increment;
+            }
+            $activityToMove->setOrdre($to);
+            $movedActivities[] = new MovedActivityDto($activityToMove->getId(), $from, $to);
+            $this->entityManager->persist($activityToMove);
+        }
+        $this->entityManager->flush();
+        return $movedActivities;
+    }
+}

--- a/src/Service/KermesseService.php
+++ b/src/Service/KermesseService.php
@@ -165,4 +165,23 @@ class KermesseService
         $this->entityManager->flush();
         return $this;
     }
+
+    /**
+     * Permet d'initialiser l'ordre des activités de la kermesse si au moins une activité n'a pas d'ordre
+     * @param Kermesse $kermesse
+     * @return $this
+     */
+    public function initialiserOrdreActivites(Kermesse $kermesse):self {
+        $unordered = $this->rActivite->findUnorderedByKermesseId($kermesse->getId());
+        if (!empty($unordered)) {
+            $activites = $this->rActivite->findByKermesseId($kermesse->getId());
+            for ($i = 0; $i < count($activites); $i++) {
+                $activite = $activites[$i];
+                $activite->setOrdre($i+1);
+                $this->entityManager->persist($activite);
+            }
+            $this->entityManager->flush();
+        }
+        return $this;
+    }
 }

--- a/templates/activite/card.html.twig
+++ b/templates/activite/card.html.twig
@@ -1,5 +1,6 @@
 <div class="card text-center">
     <div class="card-header">
+        <i class="fas fa-grip-vertical activity-card-handle"></i>
         <h5>{{ card.titre }}{% if card.description %}
             <button type="button" class="btn btn-link" data-toggle="modal" data-target="#activite{{ card.id }}-desc-modal" style="padding: 0; border: 0;">
                 <i class="fas fa-question-circle"></i>

--- a/templates/activite/card.html.twig
+++ b/templates/activite/card.html.twig
@@ -42,7 +42,9 @@
         <div class="btn-group mb-3" role="group" aria-label="Actions">
             <a href="#" data-ajax="{{ path('nouvelle_recette_activite', {'id': card.id}) }}" class="btn btn-success ajax-reload-element" data-toggle="tooltip" title="Nouvelle recette"><i class="fas fa-donate"></i></a>
             <a href="{{ path('nouveau_ticket_action', {'id': card.id}) }}" class="btn btn-danger" data-toggle="tooltip" title="Nouvelle dépense"><i class="fas fa-receipt"></i></a>
-            <a href="{{ path('gerer_benevoles', {'id': card.id}) }}" class="btn btn-warning" data-toggle="tooltip" title="Gérer les bénévoles"><i class="fas fa-users-cog"></i></a>
+            {% if card.nombreBenevolesRequis > 0 %}
+                <a href="{{ path('gerer_benevoles', {'id': card.id}) }}" class="btn btn-warning" data-toggle="tooltip" title="Gérer les bénévoles"><i class="fas fa-users-cog"></i></a>
+            {% endif %}
         </div>
     </div>
 </div>

--- a/templates/activite/card.html.twig
+++ b/templates/activite/card.html.twig
@@ -1,6 +1,10 @@
 <div class="card text-center">
     <div class="card-header">
-        <h5>{{ card.titre }}</h5>
+        <h5>{{ card.titre }}{% if card.description %}
+            <button type="button" class="btn btn-link" data-toggle="modal" data-target="#activite{{ card.id }}-desc-modal" style="padding: 0; border: 0;">
+                <i class="fas fa-question-circle"></i>
+            </button>
+        {% endif %}</h5>
     </div>
     <div class="card-body d-flex flex-column justify-content-between" style="min-height: 205px;">
         {% if not card.activite.kermesse %}
@@ -38,6 +42,23 @@
             <a href="#" data-ajax="{{ path('nouvelle_recette_activite', {'id': card.id}) }}" class="btn btn-success ajax-reload-element" data-toggle="tooltip" title="Nouvelle recette"><i class="fas fa-donate"></i></a>
             <a href="{{ path('nouveau_ticket_action', {'id': card.id}) }}" class="btn btn-danger" data-toggle="tooltip" title="Nouvelle dépense"><i class="fas fa-receipt"></i></a>
             <a href="{{ path('gerer_benevoles', {'id': card.id}) }}" class="btn btn-warning" data-toggle="tooltip" title="Gérer les bénévoles"><i class="fas fa-users-cog"></i></a>
+        </div>
+    </div>
+</div>
+
+<!-- Modal -->
+<div class="modal fade" id="activite{{ card.id }}-desc-modal" tabindex="-1" aria-labelledby="activite{{ card.id }}-desc-modal-label" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="activite{{ card.id }}-desc-modal-label">{{ card.titre }} - Description</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                {{ card.description|nl2br }}
+            </div>
         </div>
     </div>
 </div>

--- a/templates/activite/card.html.twig
+++ b/templates/activite/card.html.twig
@@ -1,7 +1,7 @@
 <div class="card text-center">
     <div class="card-header">
         <i class="fas fa-grip-vertical activity-card-handle"></i>
-        <h5>{{ card.titre }}{% if card.description %}
+        <h5>{{ card.titre }}{% if not card.description.empty %}
             <button type="button" class="btn btn-link" data-toggle="modal" data-target="#activite{{ card.id }}-desc-modal" style="padding: 0; border: 0;">
                 <i class="fas fa-question-circle"></i>
             </button>
@@ -49,19 +49,7 @@
     </div>
 </div>
 
-<!-- Modal -->
-<div class="modal fade" id="activite{{ card.id }}-desc-modal" tabindex="-1" aria-labelledby="activite{{ card.id }}-desc-modal-label" aria-hidden="true">
-    <div class="modal-dialog">
-        <div class="modal-content">
-            <div class="modal-header">
-                <h5 class="modal-title" id="activite{{ card.id }}-desc-modal-label">{{ card.titre }} - Description</h5>
-                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                    <span aria-hidden="true">&times;</span>
-                </button>
-            </div>
-            <div class="modal-body">
-                {{ card.description|nl2br }}
-            </div>
-        </div>
-    </div>
-</div>
+{% if not card.description.empty %}
+    <!-- Modal -->
+    {% include "activite/description-modal.html.twig" with {'id': card.id, 'titre': card.titre, 'contentModal': card.description} only %}
+{% endif %}

--- a/templates/activite/description-modal.html.twig
+++ b/templates/activite/description-modal.html.twig
@@ -1,0 +1,24 @@
+<div class="modal fade" id="activite{{ id }}-desc-modal" tabindex="-1" aria-labelledby="activite{{ id }}-desc-modal-label" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="activite{{ id }}-desc-modal-label">{{ titre }}</h5>
+                <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                    <span aria-hidden="true">&times;</span>
+                </button>
+            </div>
+            <div class="modal-body">
+                <dl>
+                    {% if contentModal.type %}
+                        <dt>Type</dt>
+                        <dd>{{ contentModal.type }}</dd>
+                    {% endif %}
+                    {% if contentModal.description %}
+                        <dt>Description</dt>
+                        <dd>{{ contentModal.description|nl2br }}</dd>
+                    {% endif %}
+                </dl>
+            </div>
+        </div>
+    </div>
+</div>

--- a/templates/activite/description-modal.html.twig
+++ b/templates/activite/description-modal.html.twig
@@ -17,6 +17,10 @@
                         <dt>Description</dt>
                         <dd>{{ contentModal.description|nl2br }}</dd>
                     {% endif %}
+                    {% if contentModal.regle %}
+                        <dt>Règles du jeu</dt>
+                        <dd>{{ contentModal.regle|nl2br }}</dd>
+                    {% endif %}
                 </dl>
             </div>
         </div>

--- a/templates/activite/form.html.twig
+++ b/templates/activite/form.html.twig
@@ -5,7 +5,6 @@
 {% block stylesheets %}<link rel="stylesheet" href="{{ asset('css/activite_form.css') }}">{% endblock %}
 
 {% block body %}
-    {{ form_row(form.ordre) }}
     {{ form_row(form.nom) }}
     {{ form_row(form.date) }}
     {{ form_row(form.description) }}

--- a/templates/activite/form.html.twig
+++ b/templates/activite/form.html.twig
@@ -10,8 +10,8 @@
     {{ form_row(form.type) }}
     {{ form_row(form.new_type_activite) }}
     {{ form_row(form.description) }}
+    {{ form_row(form.regle) }}
     {% if kermesse is not null %}
-        <!-- TODO : Do some JS to hide accepteTicket if only for planning and hide nombre de bénévoles -->
         {{ form_row(form.onlyForPlanning) }}
         {{ form_row(form.accepteTickets) }}
         <div class="well">

--- a/templates/activite/form.html.twig
+++ b/templates/activite/form.html.twig
@@ -5,6 +5,7 @@
 {% block stylesheets %}<link rel="stylesheet" href="{{ asset('css/activite_form.css') }}">{% endblock %}
 
 {% block body %}
+    {{ form_row(form.ordre) }}
     {{ form_row(form.nom) }}
     {{ form_row(form.date) }}
     {{ form_row(form.description) }}

--- a/templates/activite/form.html.twig
+++ b/templates/activite/form.html.twig
@@ -9,6 +9,8 @@
     {{ form_row(form.date) }}
     {{ form_row(form.description) }}
     {% if kermesse is not null %}
+        <!-- TODO : Do some JS to hide accepteTicket if only for planning and hide nombre de bénévoles -->
+        {{ form_row(form.onlyForPlanning) }}
         {{ form_row(form.accepteTickets) }}
         <div class="well">
             <fieldset>

--- a/templates/activite/form.html.twig
+++ b/templates/activite/form.html.twig
@@ -7,6 +7,8 @@
 {% block body %}
     {{ form_row(form.nom) }}
     {{ form_row(form.date) }}
+    {{ form_row(form.type) }}
+    {{ form_row(form.new_type_activite) }}
     {{ form_row(form.description) }}
     {% if kermesse is not null %}
         <!-- TODO : Do some JS to hide accepteTicket if only for planning and hide nombre de bénévoles -->

--- a/templates/activite/form.html.twig
+++ b/templates/activite/form.html.twig
@@ -7,6 +7,7 @@
 {% block body %}
     {{ form_row(form.nom) }}
     {{ form_row(form.date) }}
+    {{ form_row(form.description) }}
     {% if kermesse is not null %}
         {{ form_row(form.accepteTickets) }}
         <div class="well">

--- a/templates/kermesse/index.html.twig
+++ b/templates/kermesse/index.html.twig
@@ -1,17 +1,15 @@
 {% extends 'base.html.twig' %}
 
-{% block stylesheets %}<style>
-    .loader {
-        height: 310px;
-    }
-</style>{% endblock %}
+{% block stylesheets %}
+    <link rel="stylesheet" href="{{ asset('css/kermesse_index.css') }}" />
+{% endblock %}
 
 {% block title %}Kermesse{% endblock %}
 
 {% block body %}
     <fieldset>
         <legend>Activités <a href="#" data-ajax="{{ path('nouvelle_activite', {'id': kermesse.id}) }}" class="btn btn-primary ajax-reload" data-toggle="tooltip" title="Nouvelle activité"><i class="fas fa-plus"></i></a></legend>
-        <div class="row">
+        <div id="activity-list" class="row">
             {% if activites is empty %}
             <div class="col-sm-6 col-md-4 col-lg-3">
                 <div class="card text-center">
@@ -20,9 +18,16 @@
             </div>
             {% endif %}
             {% for activite in activites %}
-                <div class="col-sm-6 col-md-4 col-lg-3 mb-3 ajax" data-ajax-url="{{ path('carte_activite', {'id': activite.id}) }}">
+                <div
+                        class="activity-card col-sm-6 col-md-4 col-lg-3 mb-3 ajax"
+                        data-move-url="{{ path('move_activity', {'id': activite.id, 'position': '__position__'}) }}"
+                        data-ajax-url="{{ path('carte_activite', {'id': activite.id}) }}">
                 </div>
             {% endfor %}
         </div>
     </fieldset>
+{% endblock %}
+
+{% block javascripts %}
+    <script src="{{ asset('js/kermesse_index.js') }}"></script>
 {% endblock %}

--- a/templates/kermesse/planning.html.twig
+++ b/templates/kermesse/planning.html.twig
@@ -56,8 +56,8 @@
                 <div class="col ligne-activites">
                     {% for activite in ligne.activites %}
                         <div class="row ligne-activite mb-1">
-                            <div class="col-2 activite-nom">{{ activite.nom }}{% if activite.description %}
-                                    <button type="button" class="btn btn-link activite-desc-btn" data-activite="{{ activite.nom }}" data-description="{{ activite.description }}" data-toggle="modal" data-target="#activite-desc-modal" style="padding: 0; border: 0;">
+                            <div class="col-2 activite-nom">{{ activite.nom }}{% if activite.description and not activite.description.empty %}
+                                    <button type="button" class="btn btn-link activite-desc-btn" data-toggle="modal" data-target="#activite{{ activite.id }}-desc-modal" style="padding: 0; border: 0;">
                                         <i class="fas fa-question-circle"></i>
                                     </button>
                                 {% endif %}</div>
@@ -168,22 +168,15 @@
             >Copier le lien à fournir aux bénévoles</button>
             <a href="{{ path('planning_valider', {'id': planning.idKermesse}) }}" class="btn btn-primary" role="button"><i class="far fa-calendar-check"></i> Valider le planning</a>
         </div>
+        <!-- Modals -->
         <div id="modal-migration" class="modal" tabindex="-1" role="dialog"></div>
-        <!-- Modal -->
-        <div class="modal fade" id="activite-desc-modal" tabindex="-1" aria-labelledby="activite-desc-modal-label" aria-hidden="true">
-            <div class="modal-dialog">
-                <div class="modal-content">
-                    <div class="modal-header">
-                        <h5 class="modal-title" id="activite-desc-modal-label"><span id="activite-desc-modal-title"></span> - Description</h5>
-                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
-                            <span aria-hidden="true">&times;</span>
-                        </button>
-                    </div>
-                    <div class="modal-body" style="white-space: pre-line">
-                    </div>
-                </div>
-            </div>
-        </div>
+        {% for ligne in planning.lignes %}
+            {% for activite in ligne.activites %}
+                {% if activite.description and not activite.description.empty %}
+                    {% include "activite/description-modal.html.twig" with {'id': activite.id, 'titre': activite.nom, 'contentModal': activite.description} only %}
+                {% endif %}
+            {% endfor %}
+        {% endfor %}
     {% endif %}
 {% endblock %}
 

--- a/templates/kermesse/planning.html.twig
+++ b/templates/kermesse/planning.html.twig
@@ -27,7 +27,7 @@
         {{ include('kermesse/progress.html.twig', {el: planning}, with_context = false) }}
     </div>
 
-    <div id="planning" class="d-none d-lg-block" style="position: relative;">
+    <div id="planning" class="d-none d-lg-block activite-desc-listener" style="position: relative;">
         <div class="row pt-3 pb-3 border-bottom">
             <div class="col-1">Date</div>
             <div class="col">
@@ -56,7 +56,11 @@
                 <div class="col ligne-activites">
                     {% for activite in ligne.activites %}
                         <div class="row ligne-activite mb-1">
-                            <div class="col-2 activite-nom">{{ activite.nom }}</div>
+                            <div class="col-2 activite-nom">{{ activite.nom }}{% if activite.description %}
+                                    <button type="button" class="btn btn-link activite-desc-btn" data-activite="{{ activite.nom }}" data-description="{{ activite.description }}" data-toggle="modal" data-target="#activite-desc-modal" style="padding: 0; border: 0;">
+                                        <i class="fas fa-question-circle"></i>
+                                    </button>
+                                {% endif %}</div>
                             <div class="col activite-lignes-creneaux">
                             {% for ligneCreneaux in activite.lignesCreneaux %}
                                 <div class="row activite-ligne-creneaux">
@@ -134,7 +138,7 @@
             </div>
         {% endfor %}
     </div>
-    <div class="d-lg-none row pt-3 pb-3 border-bottom">
+    <div class="d-lg-none row pt-3 pb-3 border-bottom activite-desc-listener">
         {% for ligne in planning.lignes %}
             {% for activite in ligne.activites %}
                 <div class="col-sm-6 mb-3">
@@ -165,6 +169,21 @@
             <a href="{{ path('planning_valider', {'id': planning.idKermesse}) }}" class="btn btn-primary" role="button"><i class="far fa-calendar-check"></i> Valider le planning</a>
         </div>
         <div id="modal-migration" class="modal" tabindex="-1" role="dialog"></div>
+        <!-- Modal -->
+        <div class="modal fade" id="activite-desc-modal" tabindex="-1" aria-labelledby="activite-desc-modal-label" aria-hidden="true">
+            <div class="modal-dialog">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="activite-desc-modal-label"><span id="activite-desc-modal-title"></span> - Description</h5>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                    </div>
+                    <div class="modal-body" style="white-space: pre-line">
+                    </div>
+                </div>
+            </div>
+        </div>
     {% endif %}
 {% endblock %}
 

--- a/templates/kermesse/planning_card.html.twig
+++ b/templates/kermesse/planning_card.html.twig
@@ -1,4 +1,5 @@
-<div class="card text-center {% if (activite.progress < 50) %}
+<div class="card text-center {% if (activite.progress < 50use Doctrine\ORM\NonUniqueResultException;
+) %}
                             border-danger
                             {% elseif (activite.progress >= 50 and activite.progress < 75) %}
                             border-warning
@@ -8,8 +9,8 @@
                             border-success
                         {% endif %}">
     <div class="card-header">
-        <h5>{{ activite.nom }} - Le {{ dateact|date('d/m/Y') }}{% if activite.description %}
-                <button type="button" class="btn btn-outline-info activite-desc-btn" data-activite="{{ activite.nom }}" data-description="{{ activite.description }}" data-toggle="modal" data-target="#activite-desc-modal">
+        <h5>{{ activite.nom }} - Le {{ dateact|date('d/m/Y') }}{% if activite.description and not activite.description.empty %}
+                <button type="button" class="btn btn-outline-info activite-desc-btn" data-toggle="modal" data-target="#activite{{ activite.id }}-desc-modal">
                     <i class="fas fa-question-circle"></i>
                 </button>
             {% endif %}</h5>

--- a/templates/kermesse/planning_card.html.twig
+++ b/templates/kermesse/planning_card.html.twig
@@ -8,7 +8,11 @@
                             border-success
                         {% endif %}">
     <div class="card-header">
-        <h5>{{ activite.nom }} - Le {{ dateact|date('d/m/Y') }}</h5>
+        <h5>{{ activite.nom }} - Le {{ dateact|date('d/m/Y') }}{% if activite.description %}
+                <button type="button" class="btn btn-outline-info activite-desc-btn" data-activite="{{ activite.nom }}" data-description="{{ activite.description }}" data-toggle="modal" data-target="#activite-desc-modal">
+                    <i class="fas fa-question-circle"></i>
+                </button>
+            {% endif %}</h5>
     </div>
     <div class="card-body d-flex flex-column justify-content-between">
         {% for ligneCreneaux in activite.lignesCreneaux %}

--- a/templates/kermesse/planning_card.html.twig
+++ b/templates/kermesse/planning_card.html.twig
@@ -1,5 +1,4 @@
-<div class="card text-center {% if (activite.progress < 50use Doctrine\ORM\NonUniqueResultException;
-) %}
+<div class="card text-center {% if (activite.progress < 50) %}
                             border-danger
                             {% elseif (activite.progress >= 50 and activite.progress < 75) %}
                             border-warning

--- a/templates/modal.html.twig
+++ b/templates/modal.html.twig
@@ -4,7 +4,7 @@
         {{ form_start(form) }}
         <div class="modal-header">
             <h5 class="modal-title" id="main-modal-form-title">{% block title %}Formulaire{% endblock %}</h5>
-            <button type="button" class="close dismiss" aria-label="Fermer">
+            <button type="button" class="close dismiss" aria-label="Fermer" data-dismiss="modal">
                 <span aria-hidden="true">&times;</span>
             </button>
         </div>
@@ -13,7 +13,7 @@
         </div>
         {% block buttons %}
             <div class="modal-footer">
-                <button type="button" class="btn btn-secondary dismiss">Annuler</button>
+                <button type="button" class="btn btn-secondary dismiss" data-dismiss="modal">Annuler</button>
                 {% block sendbutton %}<button class="btn btn-primary" type="submit">Enregistrer</button>{% endblock %}
             </div>
         {% endblock %}


### PR DESCRIPTION
FIX #84 
Ajout de tout un tas d’améliorations et d’ajouts pour la gestion des activités : 
- Possibilité de déterminer un type d’activité (et même d’en créer des nouveaux)
- Possibilité d’ajouter un descriptif
- Possibilité d’ajouter des règles du jeu
- Toutes ces informations sont affichable via un bouton « point d’interrogation » dans le planning (et dans la vue de gestion)